### PR TITLE
Fix Jenkins (Hudson) incubation year

### DIFF
--- a/src/chapters/03-jenkins-and-blue-ocean.adoc
+++ b/src/chapters/03-jenkins-and-blue-ocean.adoc
@@ -8,7 +8,7 @@ image::{imagedir}/jenkins_logo.png[height="200"]
 
 * Task orchestrator
 * Open-Source software written in Java
-* One of the first and most popular Continous Integration Engine (2004)
+* One of the first and most popular Continous Integration Engine (2006)
 * Plugin based
 
 == Jenkins Pipelines


### PR DESCRIPTION
Jenkins (Hudson) was created in 2006 (or at least publicly released then).

Is that correct @kohsuke?